### PR TITLE
Add the git url in the README.md install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add Guard::Nosetests to your `Gemfile`:
 
 ```ruby
 group :development do
-  gem 'guard-nosetests'
+  gem 'guard-nosetests', :git => 'https://github.com/medihack/guard-nosetests.git'
 end
 ```
 


### PR DESCRIPTION
After following the installation instructions I got the following error:

$ bundle
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/..
Resolving dependencies...
Could not find gem 'guard-nosetests (>= 0) ruby' in the gems available on this machine.

I manage to make it work by adding the url of the git repo to the Gemfile. This might help the next users while the issue with rubygems.org is fixed.
